### PR TITLE
8章完了

### DIFF
--- a/laravel/app/Article.php
+++ b/laravel/app/Article.php
@@ -35,4 +35,8 @@ class Article extends Model
 
         return $this->likes->count();
     }
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany("App\Tag")->withTimestamps();
+    }
 }

--- a/laravel/app/Http/Controllers/ArticleController.php
+++ b/laravel/app/Http/Controllers/ArticleController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Article;
+use App\Tag;
 use App\Http\ArticleRequest;
 use App\Http\Requests\ArticleRequest as RequestsArticleRequest;
 
@@ -21,23 +22,42 @@ class ArticleController extends Controller
     }
     public function create()
     {
-        return view("articles.create");
+        $allTagNames = Tag::all()->map(function ($tag) {
+            return ["text" => $tag->name];
+        });
+        return view("articles.create", ["allTagNames" => $allTagNames]);
     }
     public function store(RequestsArticleRequest $request, Article $article)
     {
         $article->fill($request->all());
         $article->user_id = $request->user()->id;
         $article->save();
+        $request->tags->each(function ($tagName) use ($article) {
+            $tag = Tag::firstOrCreate(["name" => $tagName]);
+            $article->tags()->attach($tag);
+        });
         return redirect()->route("articles.index");
     }
 
     public function edit(Article $article)
     {
-        return view("articles.edit", ["article" => $article]);
+        $tagNames = $article->tags->map(function ($tag) {
+            return ["text" => $tag->name];
+        });
+        $allTagNames = Tag::all()->map(function ($tag) {
+            return ["text" => $tag->name];
+        });
+
+        return view("articles.edit", ["article" => $article, "tagNames" => $tagNames, "allTagNames" => $allTagNames]);
     }
     public function update(RequestsArticleRequest $request, Article $article)
     {
         $article->fill($request->all())->save();
+        $article->tags()->detach();
+        $request->tags->each(function ($tagName) use ($article) {
+            $tag = Tag::firstOrCreate(["name" => $tagName]);
+            $article->tags()->attach($tag);
+        });
         return redirect()->route("articles.index");
     }
     public function destroy(Article $article)

--- a/laravel/app/Http/Controllers/TagController.php
+++ b/laravel/app/Http/Controllers/TagController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Tag;
+
+class TagController extends Controller
+{
+    public function show(string $name)
+    {
+        $tag = Tag::where("name", $name)->first();
+        return view("tags.show", ["tag" => $tag]);
+    }
+}

--- a/laravel/app/Http/Requests/ArticleRequest.php
+++ b/laravel/app/Http/Requests/ArticleRequest.php
@@ -26,6 +26,7 @@ class ArticleRequest extends FormRequest
         return [
             'title' => 'required|max:50',
             'body' => 'required|max:500',
+            'tags' => 'json|regex:/^(?!.*\s).+$/u|regex:/^(?!.*\/).*$/u',
         ];
     }
 
@@ -34,6 +35,15 @@ class ArticleRequest extends FormRequest
         return [
             "title" => "タイトル",
             "body" => "本文",
+            "tag" => "タグ",
         ];
+    }
+    public function passedValidation()
+    {
+        $this->tags = collect(json_decode($this->tags))
+            ->slice(0, 5)
+            ->map(function ($requestTag) {
+                return $requestTag->text;
+            });
     }
 }

--- a/laravel/app/Tag.php
+++ b/laravel/app/Tag.php
@@ -3,6 +3,8 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Tag extends Model
 {
@@ -12,5 +14,10 @@ class Tag extends Model
     public function getHashtagAttribute(): string
     {
         return "#" . $this->name;
+    }
+
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany("App\Article")->withTimestamps();
     }
 }

--- a/laravel/app/Tag.php
+++ b/laravel/app/Tag.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = [
+        "name",
+    ];
+    public function getHashtagAttribute(): string
+    {
+        return "#" . $this->name;
+    }
+}

--- a/laravel/composer.json
+++ b/laravel/composer.json
@@ -14,6 +14,7 @@
         "laravel/tinker": "^1.0"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.5",
         "filp/whoops": "^2.0",
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",

--- a/laravel/composer.lock
+++ b/laravel/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "40108d89c2e7a6e798ffb68e0d48fa91",
+    "content-hash": "46c166adb1be7fb2cc4472b4c22ffc5e",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -3801,6 +3801,83 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v3.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-debugbar.git",
+                "reference": "cae0a8d1cb89b0f0522f65e60465e16d738e069b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/cae0a8d1cb89b0f0522f65e60465e16d738e069b",
+                "reference": "cae0a8d1cb89b0f0522f65e60465e16d738e069b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^6|^7|^8",
+                "illuminate/session": "^6|^7|^8",
+                "illuminate/support": "^6|^7|^8",
+                "maximebf/debugbar": "^1.16.3",
+                "php": ">=7.2",
+                "symfony/debug": "^4.3|^5",
+                "symfony/finder": "^4.3|^5"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^4|^5|^6",
+                "phpunit/phpunit": "^8.5|^9.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.5-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facade"
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\Debugbar\\": "src/"
+                },
+                "files": [
+                    "src/helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "debug",
+                "debugbar",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-01-06T14:21:44+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -4029,6 +4106,67 @@
                 "test"
             ],
             "time": "2020-07-09T08:09:16+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.16.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "6d51ee9e94cff14412783785e79a4e7ef97b9d62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/6d51ee9e94cff14412783785e79a4e7ef97b9d62",
+                "reference": "6d51ee9e94cff14412783785e79a4e7ef97b9d62",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8",
+                "psr/log": "^1.0",
+                "symfony/var-dumper": "^2.6|^3|^4|^5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5.20 || ^9.4.2"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.16-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "time": "2020-12-07T11:07:24+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/laravel/database/migrations/2021_03_04_090320_create_tags_table.php
+++ b/laravel/database/migrations/2021_03_04_090320_create_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string("name")->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.p
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/laravel/database/migrations/2021_03_04_090724_create_article_tag_table.php
+++ b/laravel/database/migrations/2021_03_04_090724_create_article_tag_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArticleTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger("article_id");
+            $table->foreign("article_id")
+                ->references("id")
+                ->on("articles")
+                ->onDelete("cascade");
+            $table->bigInteger("tag_id");
+            $table->foreign("tag_id")
+                ->references("id")
+                ->on("tags")
+                ->onDelete("cascade");
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tag');
+    }
+}

--- a/laravel/package-lock.json
+++ b/laravel/package-lock.json
@@ -1078,6 +1078,15 @@
             "integrity": "sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==",
             "dev": true
         },
+        "@johmun/vue-tags-input": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@johmun/vue-tags-input/-/vue-tags-input-2.1.0.tgz",
+            "integrity": "sha512-Fdwfss/TqCqMJbGAkmlzKbcG/ia1MstYjhqPBj+zG7h/166tIcE1TIftUxhT9LZ+RWjRSG0EFA1UyaHQSr3k3Q==",
+            "dev": true,
+            "requires": {
+                "vue": "^2.6.10"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",

--- a/laravel/package.json
+++ b/laravel/package.json
@@ -10,6 +10,7 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
+        "@johmun/vue-tags-input": "^2.1.0",
         "axios": "^0.21.1",
         "cross-env": "^5.1",
         "laravel-mix": "^6.0.13",

--- a/laravel/resources/js/app.js
+++ b/laravel/resources/js/app.js
@@ -1,10 +1,11 @@
 import './bootstrap'
 import Vue from 'vue'
 import ArticleLike from './components/ArticleLike.vue'
-
+import ArticleTagsInput from './components/ArticleTagsInput.vue'
 const app = new Vue({
   el: '#app',
   components: {
     ArticleLike,
+    ArticleTagsInput,
   }
 })

--- a/laravel/resources/js/components/ArticleTagsInput.vue
+++ b/laravel/resources/js/components/ArticleTagsInput.vue
@@ -6,6 +6,7 @@
       :tags="tags"
       placeholder="タグを5個まで入力できます"
       :autocomplete-items="filteredItems"
+      :add-on-key="[13,32]"
       @tags-changed="newTags => tags = newTags"
     />
   </div>

--- a/laravel/resources/js/components/ArticleTagsInput.vue
+++ b/laravel/resources/js/components/ArticleTagsInput.vue
@@ -1,0 +1,72 @@
+<template>
+  <div>
+    <input type="hidden" name="tags" :value="tagsJson">
+   <vue-tags-input
+      v-model="tag"
+      :tags="tags"
+      placeholder="タグを5個まで入力できます"
+      :autocomplete-items="filteredItems"
+      @tags-changed="newTags => tags = newTags"
+    />
+  </div>
+</template>
+
+<script>
+import VueTagsInput from "@johmun/vue-tags-input";
+export default {
+  components:{
+    VueTagsInput,
+  },
+  props:{
+  initialTags:{
+    type: Array,
+    defalt: [],
+  },
+  autocompleteItems:{
+    type: Array,
+    defalt:[],
+  },
+  },
+  data(){
+    return{
+      tag:"",
+      tags: this.initialTags,
+    };
+  },
+  computed:{
+    filteredItems(){
+      return this.autocompleteItems.filter(i=>{
+        return i.text.toLowerCase().indexOf(this.tag.toLowerCase())!==-1;
+      });
+    },
+  tagsJson(){
+    return JSON.stringify(this.tags)
+  },
+  },
+};
+</script>
+
+
+
+
+
+
+
+<style lang="css" scoped>
+  .vue-tags-input {
+    max-width: inherit;
+  }
+</style>
+<style lang="css">
+  .vue-tags-input .ti-tag {
+    background: transparent;
+    border: 1px solid #747373;
+    color: #747373;
+    margin-right: 4px;
+    border-radius: 0px;
+    font-size: 13px;
+  }
+   .vue-tags-input .ti-tag::before {
+    content: "#";
+  }
+</style>

--- a/laravel/resources/views/articles/card.blade.php
+++ b/laravel/resources/views/articles/card.blade.php
@@ -75,4 +75,17 @@
       </article-like>
     </div>
   </div>
+   @foreach($article->tags as $tag)
+    @if($loop->first)
+      <div class="card-body pt-0 pb-4 pl-3">
+        <div class="card-text line-height">
+    @endif
+          <a href="" class="border p-1 mr-1 mt-1 text-muted">
+            {{ $tag->hashtag}}
+          </a>
+    @if($loop->last)
+        </div>
+      </div>
+    @endif
+  @endforeach
 </div>

--- a/laravel/resources/views/articles/card.blade.php
+++ b/laravel/resources/views/articles/card.blade.php
@@ -80,7 +80,7 @@
       <div class="card-body pt-0 pb-4 pl-3">
         <div class="card-text line-height">
     @endif
-          <a href="" class="border p-1 mr-1 mt-1 text-muted">
+          <a href="{{ route('tags.show', ['name' => $tag->name]) }}" class="border p-1 mr-1 mt-1 text-muted">
             {{ $tag->hashtag}}
           </a>
     @if($loop->last)

--- a/laravel/resources/views/articles/form.blade.php
+++ b/laravel/resources/views/articles/form.blade.php
@@ -4,6 +4,15 @@
   <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
 <div class="form-group">
+  <article-tags-input
+  :initial-tags='@json($tagNames ?? [])'
+  :autocomplete-items='@json($allTagNames ?? [])'
+  >
+
+  </article-tags-input>
+
+</div>
+<div class="form-group">
   <label></label>
   <textarea name="body" required class="form-control" rows="16" placeholder="本文">{{$article->body ?? old('body') }}</textarea>
 </div>

--- a/laravel/resources/views/tags/show.blade.php
+++ b/laravel/resources/views/tags/show.blade.php
@@ -1,0 +1,20 @@
+@extends('app')
+
+@section('title', $tag->hashtag)
+
+@section('content')
+  @include('nav')
+  <div class="container">
+    <div class="card mt-3">
+      <div class="card-body">
+        <h2 class="h4 card-title m-0">{{ $tag->hashtag }}</h2>
+        <div class="card-text text-right">
+          {{ $tag->articles->count() }}件
+        </div>
+      </div>
+    </div>
+    @foreach($tag->articles as $article)
+      @include('articles.card')
+    @endforeach
+  </div>
+@endsection

--- a/laravel/routes/web.php
+++ b/laravel/routes/web.php
@@ -30,3 +30,4 @@ Route::prefix("articles")->name("articles.")->group(function () {
   Route::put("/{article}/like", "ArticleController@like")->name("like")->middleware("auth");
   Route::delete("/{article}/like", "ArticleController@unlike")->name("unlike")->middleware("auth");
 });
+Route::get("/tags/{name}", "TagController@show")->name("tags.show");

--- a/laravel/storage/debugbar/.gitignore
+++ b/laravel/storage/debugbar/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
# タグ機能実装
- debagbar導入
- タグ入力のvueコンポーネントを表示する
- 入力されたタグをBladeからPOST送信可能にする
- tagsテーブル、article_tagテーブル作成
- tagモデルと記事モデルをbelongsToManyで紐づける
- ArricleRequestを編集し、バリテーション追加
- 記事へのタグ表示とタグ登録の動作確認
- 記事更新処理でタグを登録可能にする
- タグの自動補完を行う
- タグをハッシュタグ風に表示する
- タグごとの記事一覧画面を作る
- タグ入力フォームの確定キー種類をカスタマイズする